### PR TITLE
Bare bones project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@
 *.DS_Store
 *.aps
 *.autosave
+*.pyc
 CMakeLists.txt.user.*
 build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,130 @@
+# Copyright (c) 2024 IHU Liryc, Université de Bordeaux, Inria.
+# License: BSD-3-Clause
+
+cmake_minimum_required(VERSION 3.19)
+
+################################################################################
+# Version
+################################################################################
+
+find_package(Git)
+set(_success FALSE)
+
+if(GIT_EXECUTABLE)
+    execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --always
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        OUTPUT_VARIABLE _git_describe
+        )
+
+    if (_git_describe MATCHES "^v([0-9]+)\\.([0-9]+)(-([0-9]+))?.*$")
+        set(MBOX_VERSION_MAJOR ${CMAKE_MATCH_1})
+        set(MBOX_VERSION_MINOR ${CMAKE_MATCH_2})
+        if(CMAKE_MATCH_4)
+            set(MBOX_VERSION_PATCH ${CMAKE_MATCH_4})
+        else()
+            set(MBOX_VERSION_PATCH 0)
+        endif()
+        set(_success TRUE)
+    endif()
+endif()
+
+if(_success)
+    message(STATUS "MusicBox version number generated from git: ${MBOX_VERSION_MAJOR}.${MBOX_VERSION_MINOR}.${MBOX_VERSION_PATCH}")
+else()
+    set(MBOX_VERSION_MAJOR 0)
+    set(MBOX_VERSION_MINOR 0)
+    set(MBOX_VERSION_PATCH 0)
+    message(WARNING "Cannot use git to generate a version number. Defaulting to 0.0.0")
+endif()
+
+################################################################################
+# Project
+################################################################################
+
+set(MBOX_VERSION "${MBOX_VERSION_MAJOR}.${MBOX_VERSION_MINOR}.${MBOX_VERSION_PATCH}")
+
+project(musicbox VERSION "${MBOX_VERSION}")
+
+################################################################################
+# CMake modules
+################################################################################
+
+include(CMakeDependentOption)
+include(CTest)
+
+################################################################################
+# Settings
+################################################################################
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+get_property(GENERATOR_IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+
+if(NOT GENERATOR_IS_MULTI_CONFIG AND NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+set(FETCHCONTENT_BASE_DIR "${CMAKE_BINARY_DIR}")
+
+set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+
+option(MBOX_STANDALONE "Build standalone" OFF)
+
+if(APPLE)
+    cmake_dependent_option(MBOX_MACOS_BUNDLE "Build standalone as a bundle" ON "MBOX_STANDALONE" OFF)
+endif()
+
+cmake_dependent_option(MBOX_VIRTUAL_ENV "Create a virtual environment in the build directory" OFF "NOT MBOX_STANDALONE" OFF)
+
+option(MBOX_USE_QT5 "Use Qt5 instead of Qt6" OFF)
+
+if(MBOX_USE_QT5)
+    set(MBOX_QT_PACKAGE "Qt5")
+    set(MBOX_PYSIDE_PACKAGE "PySide2")
+    set(MBOX_SHIBOKEN_PACKAGE "shiboken2")
+else()
+    set(MBOX_QT_PACKAGE "Qt6")
+    set(MBOX_PYSIDE_PACKAGE "PySide6")
+    set(MBOX_SHIBOKEN_PACKAGE "shiboken6")
+endif()
+
+################################################################################
+# Paths
+################################################################################
+
+set(MBOX_ROOT_BASE "${CMAKE_CURRENT_BINARY_DIR}")
+set(MBOX_ROOT "${MBOX_ROOT_BASE}/$<CONFIG>")
+set(MBOX_PACKAGE_ROOT "${MBOX_ROOT}/packages")
+set(MBOX_VIRTUAL_ENV_ROOT "${MBOX_ROOT}/venv")
+
+if(UNIX)
+    if(APPLE AND MBOX_MACOS_BUNDLE)
+        set(contents_subdir "MusicBox.app/Contents")
+        set(MBOX_STANDALONE_LIBRARY_SUBDIR "${contents_subdir}/Frameworks")
+        set(MBOX_STANDALONE_RUNTIME_SUBDIR "${contents_subdir}/MacOS")
+    else()
+        set(MBOX_STANDALONE_RUNTIME_SUBDIR "bin")
+        set(MBOX_STANDALONE_LIBRARY_SUBDIR "lib")
+    endif()
+
+    set(MBOX_PACKAGE_RUNTIME_SUBDIR "bin")
+    set(MBOX_PACKAGE_LIBRARY_SUBDIR "lib")
+    set(MBOX_PACKAGE_ARCHIVE_SUBDIR "lib")
+    set(MBOX_PACKAGE_SHARE_SUBDIR "share/cmake/mbox")
+else()
+    set(MBOX_STANDALONE_RUNTIME_SUBDIR "bin")
+    set(MBOX_STANDALONE_LIBRARY_SUBDIR "bin")
+    set(MBOX_PACKAGE_RUNTIME_SUBDIR "bin")
+    set(MBOX_PACKAGE_LIBRARY_SUBDIR "bin")
+    set(MBOX_PACKAGE_ARCHIVE_SUBDIR "libs")
+    set(MBOX_PACKAGE_SHARE_SUBDIR "cmake")
+endif()
+
+set(MBOX_PACKAGE_INCLUDE_SUBDIR "include")
+
+################################################################################
+# Subdirectories
+################################################################################
+
+add_subdirectory(source)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 IHU Liryc, Université de Bordeaux, Inria.
+# License: BSD-3-Clause
+
+add_subdirectory(package)
+
+if(MBOX_STANDALONE)
+    add_subdirectory(standalone)
+endif()

--- a/source/package/CMakeLists.txt
+++ b/source/package/CMakeLists.txt
@@ -1,0 +1,47 @@
+# Copyright (c) 2024 IHU Liryc, Université de Bordeaux, Inria.
+# License: BSD-3-Clause
+
+file(GLOB_RECURSE sources RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.py"
+    )
+
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/setup.py"
+    "${CMAKE_CURRENT_BINARY_DIR}/setup.py"
+    @ONLY)
+
+add_custom_target(mbox_package ALL
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${MBOX_PACKAGE_ROOT}/musicbox"
+    COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/musicbox" "${MBOX_PACKAGE_ROOT}/musicbox/musicbox"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/setup.py" "${MBOX_PACKAGE_ROOT}/musicbox/"
+    SOURCES ${sources}
+    VERBATIM
+    )
+
+if(MBOX_VIRTUAL_ENV)
+    find_package(Python 3 REQUIRED)
+
+    if(NOT Python_FOUND)
+        message(FATAL_ERROR "Cannot find Python 3 to create the virtual environment.")
+    endif()
+
+    add_custom_target(mbox_create_venv ALL
+        COMMAND ${Python_EXECUTABLE} -m venv "${MBOX_VIRTUAL_ENV_ROOT}"
+        VERBATIM
+        )
+
+    if(WIN32)
+        set(venv_bin "${MBOX_VIRTUAL_ENV_ROOT}/Scripts")
+        set(venv_python "${venv_bin}/python.exe")
+    else()
+        set(venv_bin "${MBOX_VIRTUAL_ENV_ROOT}/bin")
+        set(venv_python "${venv_bin}/python3")
+    endif()
+
+    add_custom_target(mbox_install_venv ALL
+        COMMAND "${venv_python}" -m pip install -e "${MBOX_PACKAGE_ROOT}/musicbox"
+        WORKING_DIRECTORY "${venv_bin}"
+        VERBATIM
+        )
+endif()
+
+add_test(NAME "MusicBox package" COMMAND "${venv_python}" -m musicbox --test)

--- a/source/package/musicbox/__init__.py
+++ b/source/package/musicbox/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2024 IHU Liryc, Université de Bordeaux, Inria.
+# License: BSD-3-Clause
+
+
+from . import config
+from .core import dev
+
+
+dev.add_loaded_module(__name__)
+
+
+def test_modules_list():
+    """List of modules containing test code.
+
+    (used by musicbox.dev.run_tests)
+    """
+    return []

--- a/source/package/musicbox/__main__.py
+++ b/source/package/musicbox/__main__.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2024 IHU Liryc, Université de Bordeaux, Inria.
+# License: BSD-3-Clause
+
+
+from argparse import ArgumentParser
+
+
+parser = ArgumentParser()
+parser.add_argument('--gui', action='store_true')
+parser.add_argument('--tests', action='store_true')
+args = parser.parse_args()
+
+
+if args.tests:
+    from . import dev
+    dev.run_tests()
+else:
+    from .app import run
+    run(
+        gui=args.gui,
+    )

--- a/source/package/musicbox/app/__init__.py
+++ b/source/package/musicbox/app/__init__.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2024 IHU Liryc, Université de Bordeaux, Inria.
+# License: BSD-3-Clause
+
+
+import sys
+
+from musicbox import dev
+
+from .core_application import CoreApplication
+
+
+dev.add_loaded_module(__name__)
+
+
+def run(*, gui=False):
+    if gui:
+        raise NotImplementedError("The GUI is not yet implemented.")
+    else:
+        application_class = CoreApplication
+
+    app = application_class.instance()
+
+    if app is None:
+        app = application_class()
+    else:
+        if not isinstance(app, CoreApplication):
+            raise RuntimeError("Cannot run MusicBox because another Qt application is already running.")
+
+    return app.run()

--- a/source/package/musicbox/app/core_application.py
+++ b/source/package/musicbox/app/core_application.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2024 IHU Liryc, Université de Bordeaux, Inria.
+# License: BSD-3-Clause
+
+
+import code
+from threading import Lock, Thread
+
+from musicbox import config, dev
+
+if config.pyside_version() == 2:
+    from PySide2.QtCore import QCoreApplication
+else:
+    from PySide6.QtCore import QCoreApplication
+
+
+dev.add_loaded_module(__name__)
+
+
+class CoreApplication(QCoreApplication):
+
+    _lock = Lock()
+
+    def __init__(self, argv=None):
+        super().__init__(argv=argv)
+        self.setApplicationName("MusicBox")
+        with self._lock:
+            self._is_running = False
+
+    def run(self):
+        with self._lock:
+            if self._is_running:
+                raise RuntimeError("MusicBox is already running.")
+
+        self._run_command_line()
+
+        if config.pyside_version() == 2:
+            return self._exec()
+        else:
+            return self.exec()
+
+    def _run_command_line(self):
+        """Run the Python command line on a separate thread.
+
+        The command line cannot use the main thread as that one is occupied by
+        the Qt event loop (which must be in the main thread).
+        """
+        def command_line():
+            try:
+                code.interact()
+            except SystemExit:
+                self.quit()
+
+        thread = Thread(target=command_line, name="Python command line")
+        thread.start()

--- a/source/package/musicbox/config.py
+++ b/source/package/musicbox/config.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2024 IHU Liryc, Université de Bordeaux, Inria.
+# License: BSD-3-Clause
+
+
+import importlib.util
+from threading import RLock
+
+
+_pyside_version = None
+_lock = RLock()
+
+
+def pyside_version():
+    """Return the PySide version to use in the application.
+
+    Use this function to choose which PySide modules to import.
+    """
+    with _lock:
+        global _pyside_version
+        if _pyside_version is None:
+            pyside6_spec = importlib.util.find_spec('PySide6')
+            if pyside6_spec is not None:
+                pyside_version = 6
+            else:
+                pyside2_spec = importlib.util.find_spec('PySide2')
+                if pyside2_spec is not None:
+                    pyside_version = 2
+                else:
+                    raise ModuleNotFoundError("PySide 2 or 6 is required")
+        return _pyside_version

--- a/source/package/musicbox/core/__init__.py
+++ b/source/package/musicbox/core/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2024 IHU Liryc, Université de Bordeaux, Inria.
+# License: BSD-3-Clause

--- a/source/package/musicbox/core/dev.py
+++ b/source/package/musicbox/core/dev.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2024 IHU Liryc, Université de Bordeaux, Inria.
+# License: BSD-3-Clause
+
+
+from threading import RLock
+
+
+_loaded_modules = []
+_lock = RLock()
+
+
+def add_loaded_module(name):
+    """Declare a loaded module.
+
+    Must be called from every module in the application, right after the imports.
+    (use the __name__ variable as the parameter)
+    This allows the module to be reloaded through the reload_modules() call.
+    """
+    with _lock:
+        _loaded_modules.append(name)
+
+
+add_loaded_module(__name__)
+
+
+def reload_modules():
+    """Reload all previously loaded modules.
+
+    For this to work, add_loaded_module must be used properly.
+    (see the function for more details)
+    """
+    import importlib
+    import sys
+
+    with _lock:
+        for module in _loaded_modules:
+            importlib.reload(sys.modules[module])
+
+
+def run_tests():
+    import unittest
+    import musicbox
+
+    loader = unittest.defaultTestLoader
+    suite = unittest.TestSuite()
+    
+    for module in musicbox.test_modules_list():
+        module = importlib.import_module(module)
+        suite.addTests(loader.loadTestsFromModule(module))
+
+    runner = unittest.TextTestRunner()
+    runner.run(suite)

--- a/source/package/musicbox/core/settings.py
+++ b/source/package/musicbox/core/settings.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2024 IHU Liryc, Université de Bordeaux, Inria.
+# License: BSD-3-Clause
+
+
+from musicbox import config
+
+if config.pyside_version() == 2:
+    from PySide2.QtCore import QSettings
+else:
+    from PySide6.QtCore import QSettings
+
+
+class Settings():
+
+    def __init__(self):
+        self._settings = QSettings('liryc', 'musicbox')
+
+    def value(self, name, default_value=None):
+        return self._settings.value(name, default_value)
+
+    def set_value(self, name, value):
+        self._settings.setValue(name, value)

--- a/source/package/setup.py
+++ b/source/package/setup.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2024 IHU Liryc, Université de Bordeaux, Inria.
+# License: BSD-3-Clause
+
+
+from distutils.core import setup
+from setuptools import find_packages
+
+
+setup(name='musicbox',
+      version='@PROJECT_VERSION@',
+      packages=find_packages(include=['musicbox', 'musicbox.*']),
+      install_requires=[
+      '@MBOX_PYSIDE_PACKAGE@',
+      'numpy',
+      'SimpleITK',
+      'vtk',
+      ],
+)

--- a/source/standalone/CMakeLists.txt
+++ b/source/standalone/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Copyright (c) 2024 IHU Liryc, Université de Bordeaux, Inria.
+# License: BSD-3-Clause
+
+message(FATAL_ERROR "The MBOX_STANDALONE option is currently not implemented.")


### PR DESCRIPTION
This PR provides the basic architecture of the project as described below (note that most of the features are not actually implemented in this PR, it only provides the structure and options):

The project builds a Python package and an optional standalone application (that will embed Python and run the package). The package depends on Pyside6 (or 2 if the option `MBOX_USE_QT5` is `TRUE`), as well as numpy, SimpleITK and vtk.

There is a `MBOX_VIRTUAL_ENV` option to create a virtual environment in the build directory in order to run and test the package.

The application can be run with or without a GUI using the '--gui' option.

The unit tests can be executed using one of the following methods:
- `make test`
- using the `--test` option when running the application.
- from the Python command line:
```
    import musicbox
    musicbox.dev.run_tests()
```
(there are no tests included yet)

In order to simplify development, there is a function to reload all the currently loaded MusicBox modules (in the correct order):
```
   musicbox.dev.reload_modules()
```
This avoids having to restart the application when making changes (the package installed in the virtual environment uses symlinks to the files in the source tree, so modifying the source tree files directly affects the installed package)