### PR TITLE
Add Github Action workflow

### DIFF
--- a/.github/workflows/build-and-test-multi-platform.yml
+++ b/.github/workflows/build-and-test-multi-platform.yml
@@ -1,0 +1,103 @@
+name: Build and test on all platforms
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main", "dev" ]
+  pull_request:
+    branches: [ "main", "dev" ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      
+      matrix:
+        os: [
+        ubuntu-24.04,
+        ubuntu-22.04,
+        windows-2022,
+        windows-2019,
+        macos-14,
+        macos-13,
+        ]
+        build_type: [Release]
+        c_compiler: [gcc, clang, cl]
+        include:
+          - os: ubuntu-24.04
+            c_compiler: gcc
+            cpp_compiler: g++
+          - os: ubuntu-24.04
+            c_compiler: clang
+            cpp_compiler: clang++
+          - os: ubuntu-22.04
+            c_compiler: gcc
+            cpp_compiler: g++
+          - os: ubuntu-22.04
+            c_compiler: clang
+            cpp_compiler: clang++
+          - os: windows-2022
+            c_compiler: cl
+            cpp_compiler: cl
+          - os: windows-2019
+            c_compiler: cl
+            cpp_compiler: cl
+          - os: macos-14
+            c_compiler: clang
+            cpp_compiler: clang++
+          - os: macos-13
+            c_compiler: clang
+            cpp_compiler: clang++
+        exclude:
+          - os: ubuntu-24.04
+            c_compiler: cl
+          - os: ubuntu-22.04
+            c_compiler: cl
+          - os: windows-2022
+            c_compiler: gcc
+          - os: windows-2022
+            c_compiler: clang
+          - os: windows-2019
+            c_compiler: gcc
+          - os: windows-2019
+            c_compiler: clang
+          - os: macos-14
+            c_compiler: gcc
+          - os: macos-14
+            c_compiler: cl
+          - os: macos-13
+            c_compiler: gcc
+          - os: macos-13
+            c_compiler: cl
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set reusable strings
+      id: strings
+      shell: bash
+      run: |
+        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+
+    - name: Configure CMake
+      run: >
+        cmake -B ${{ steps.strings.outputs.build-output-dir }}
+        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
+        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DMBOX_VIRTUAL_ENV=ON
+        -S ${{ github.workspace }}
+
+    - name: Build
+      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+
+    - name: Test
+      working-directory: ${{ steps.strings.outputs.build-output-dir }}
+      run: ctest --build-config ${{ matrix.build_type }} --verbose -L "TEST_NO_GUI"
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: artefacts-${{ matrix.os }}-${{ matrix.c_compiler }}-${{ matrix.build_type }}
+        path: ${{ steps.strings.outputs.build-output-dir }}/${{ matrix.build_type }}/packages/musicbox/dist/*


### PR DESCRIPTION
This workflow automatically builds and tests the project on each Pull Request and each push, on the `main` and `dev` branches, and uploads the resulting package distribution files as artefacts.

_Note: This version searches for tests with the `TEST_NO_GUI` label (to exclude GUI tests), but this label hasn't been added yet, so no tests will be found._