### PR TITLE
Handle Windows-specific issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,16 @@ endif()
 
 cmake_dependent_option(MBOX_VIRTUAL_ENV "Create a virtual environment in the build directory" OFF "NOT MBOX_STANDALONE" OFF)
 
-option(MBOX_USE_QT5 "Use Qt5 instead of Qt6" OFF)
+if(WIN32)
+    string(CONCAT symlink_message
+        "Use a symbolic link to the Python package in the source tree, so that"
+        " modifications to the source code directly affect the package installed"
+        " in the build tree (permissions to create symbolic links are necessary)."
+        )
+    option(MBOX_SYMLINK_SOURCE_PACKAGE ${symlink_message} OFF)
+else()
+    option(MBOX_USE_QT5 "Use Qt5 instead of Qt6" OFF)
+endif()
 
 if(MBOX_USE_QT5)
     set(MBOX_QT_PACKAGE "Qt5")

--- a/source/package/CMakeLists.txt
+++ b/source/package/CMakeLists.txt
@@ -1,6 +1,10 @@
 # Copyright (c) 2024 IHU Liryc, Université de Bordeaux, Inria.
 # License: BSD-3-Clause
 
+################################################################################
+# Python package
+################################################################################
+
 file(GLOB_RECURSE sources RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
     "${CMAKE_CURRENT_SOURCE_DIR}/*.py"
     )
@@ -9,13 +13,23 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/setup.py"
     "${CMAKE_CURRENT_BINARY_DIR}/setup.py"
     @ONLY)
 
+if(MBOX_SYMLINK_SOURCE_PACKAGE)
+    set(link_command create_symlink)
+else()
+    set(link_command copy_directory)
+endif()
+
 add_custom_target(mbox_package ALL
     COMMAND ${CMAKE_COMMAND} -E make_directory "${MBOX_PACKAGE_ROOT}/musicbox"
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/musicbox" "${MBOX_PACKAGE_ROOT}/musicbox/musicbox"
+    COMMAND ${CMAKE_COMMAND} -E ${link_command} "${CMAKE_CURRENT_SOURCE_DIR}/musicbox" "${MBOX_PACKAGE_ROOT}/musicbox/musicbox"
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/setup.py" "${MBOX_PACKAGE_ROOT}/musicbox/"
     SOURCES ${sources}
     VERBATIM
     )
+
+################################################################################
+# Virtual env
+################################################################################
 
 if(MBOX_VIRTUAL_ENV)
     find_package(Python 3 REQUIRED)
@@ -25,7 +39,7 @@ if(MBOX_VIRTUAL_ENV)
     endif()
 
     add_custom_target(mbox_create_venv ALL
-        COMMAND ${Python_EXECUTABLE} -m venv "${MBOX_VIRTUAL_ENV_ROOT}"
+        COMMAND ${Python_EXECUTABLE} -m venv --without-pip "${MBOX_VIRTUAL_ENV_ROOT}"
         VERBATIM
         )
 
@@ -38,6 +52,8 @@ if(MBOX_VIRTUAL_ENV)
     endif()
 
     add_custom_target(mbox_install_venv ALL
+        COMMAND "${venv_python}" -m ensurepip
+        COMMAND "${venv_python}" -m pip install build
         COMMAND "${venv_python}" -m pip install -e "${MBOX_PACKAGE_ROOT}/musicbox"
         WORKING_DIRECTORY "${venv_bin}"
         VERBATIM
@@ -45,5 +61,30 @@ if(MBOX_VIRTUAL_ENV)
 
     add_dependencies(mbox_install_venv mbox_create_venv mbox_package)
 
+    ############################################################################
+    # Runner targets
+    ############################################################################
+
+    add_custom_target(mbox_run_application
+        COMMAND "${venv_python}" -m musicbox
+        WORKING_DIRECTORY "${venv_bin}"
+        VERBATIM
+        )
+
+    add_dependencies(mbox_run_application mbox_install_venv)
+
+    add_custom_target(mbox_run_tests
+        COMMAND "${venv_python}" -m musicbox --test
+        WORKING_DIRECTORY "${venv_bin}"
+        VERBATIM
+        )
+
+    add_dependencies(mbox_run_tests mbox_install_venv)
+
+    ############################################################################
+    # CTest
+    ############################################################################
+
     add_test(NAME "MusicBox package" COMMAND "${venv_python}" -m musicbox --test)
+
 endif()

--- a/source/package/CMakeLists.txt
+++ b/source/package/CMakeLists.txt
@@ -13,7 +13,7 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/setup.py"
     "${CMAKE_CURRENT_BINARY_DIR}/setup.py"
     @ONLY)
 
-if(MBOX_SYMLINK_SOURCE_PACKAGE)
+if(UNIX OR MBOX_SYMLINK_SOURCE_PACKAGE)
     set(link_command create_symlink)
 else()
     set(link_command copy_directory)
@@ -21,6 +21,7 @@ endif()
 
 add_custom_target(mbox_package ALL
     COMMAND ${CMAKE_COMMAND} -E make_directory "${MBOX_PACKAGE_ROOT}/musicbox"
+    COMMAND ${CMAKE_COMMAND} -E rm -rf "${MBOX_PACKAGE_ROOT}/musicbox/musicbox"
     COMMAND ${CMAKE_COMMAND} -E ${link_command} "${CMAKE_CURRENT_SOURCE_DIR}/musicbox" "${MBOX_PACKAGE_ROOT}/musicbox/musicbox"
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/setup.py" "${MBOX_PACKAGE_ROOT}/musicbox/"
     SOURCES ${sources}


### PR DESCRIPTION
Feedback from the first PR and, in particular, testing on Windows raised theses issues:

- It seems PySide2 cannot be installed on recent versions of Windows. The option to use Qt5 has been removed for Windows.
- Windows users need a special permission to create symbolic links. On Windows the project gives the option to use symbolic links, and sets it to `False` by default.
- Virtual environment creation failed on the Gihub Actions Windows 2019 runner because it tries to upgrade pip. The project now takes care of ensuring pip is installed seperatley without using the upgrade option.
- The `build` package is necessary to build the distribution packages.
- Runner targets are added to easily run or test the application through the Visual Studio interface instead of the command line.
