### PR TITLE
Fix non-gui option and simplify app creation

### DIFF
--- a/source/package/musicbox/app/__init__.py
+++ b/source/package/musicbox/app/__init__.py
@@ -3,14 +3,7 @@
 
 
 from musicbox.core import dev
-from .application import application_class, init_application_class
-
-
-def instance():
-    """The current Qt application instance.
-
-    """
-    return application_class().instance()
+from .application import create, instance
 
 
 def run(*, gui=True, developer_mode=False):
@@ -26,7 +19,7 @@ def run(*, gui=True, developer_mode=False):
     app = instance()
 
     if app is None:
-        app = application_class()()
+        app = create(gui=gui)
     else:
         raise RuntimeError("Cannot run MusicBox because another Qt application is already running.")
 
@@ -35,10 +28,6 @@ def run(*, gui=True, developer_mode=False):
         dev.set_auto_reload(True)
 
     return app.run()
-
-
-def quit():
-    application_class().instance().quit()
 
 
 def main():


### PR DESCRIPTION
(based on https://github.com/LIRYC-IHU/musicbox/pull/6)
(commit: b33f1ee5dea63202057878ddcff0f413f2b23f16)

Fix the inner workings of how the application class is created and initialized. Instead of having to initialize the application class before creating an instance, there is now a simpler `create` function which does both (the reason why we create the class dynamically is because non-GUI apps must inherit from `QCoreApplication` and not `QApplication`, and in fact this option was not correctly taken into account either).
